### PR TITLE
Fix: Remove merge conflict markers from main.js

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -5,9 +5,7 @@ import {
 } from './firebase-init.js';
 import { initializeUpload } from './upload-handler.js';
 
-fix-auth-cors-errors
-const generateTextFunction = httpsCallable(functions, 'generateText');
- main
+    const generateTextFunction = httpsCallable(functions, 'generateText');
     const generateJsonFunction = httpsCallable(functions, 'generateJson');
 
     // --- API Volání ---
@@ -681,6 +679,4 @@ const generateTextFunction = httpsCallable(functions, 'generateText');
 
     function renderAnalytics(container) {
         container.innerHTML = `<div class="p-8"><h2>Analýza studentů</h2><p>Tato sekce se připravuje.</p></div>`;
- fix-auth-cors-errors
     }
- main


### PR DESCRIPTION
Removes leftover Git merge conflict markers (`fix-auth-cors-errors` and `main`) from `public/js/main.js`.

These markers were causing a JavaScript syntax error, which prevented the main application module from being parsed and executed, resulting in a blank screen on deployment.