### PR TITLE
feat: Migrate from deprecated @google-cloud/vertexai to @google/genai

### DIFF
--- a/functions/functions/package-lock.json
+++ b/functions/functions/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "functions",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "functions",
             "dependencies": {
-                "@google-cloud/vertexai": "^1.10.0",
+                "@google/genai": "latest",
                 "axios": "^1.12.2",
                 "cors": "^2.8.5",
                 "firebase-admin": "^12.6.0",
@@ -821,16 +821,25 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/@google-cloud/vertexai": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.10.0.tgz",
-            "integrity": "sha512-HqYqoivNtkq59po8m7KI0n+lWKdz4kabENncYQXZCX/hBWJfXtKAfR/2nUQsP+TwSfHKoA7zDL2RrJYIv/j3VQ==",
+        "node_modules/@google/genai": {
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.21.0.tgz",
+            "integrity": "sha512-k47DECR8BF9z7IJxQd3reKuH2eUnOH5NlJWSe+CKM6nbXx+wH3hmtWQxUQR9M8gzWW1EvFuRVgjQssEIreNZsw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "google-auth-library": "^9.1.0"
+                "google-auth-library": "^9.14.2",
+                "ws": "^8.18.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@modelcontextprotocol/sdk": "^1.11.4"
+            },
+            "peerDependenciesMeta": {
+                "@modelcontextprotocol/sdk": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@grpc/grpc-js": {
@@ -9502,6 +9511,27 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/y18n": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
                 },
     "main":  "lib/index.js",
     "dependencies":  {
-                         "@google-cloud/vertexai":  "^1.10.0",
+        "@google/genai": "latest",
                          "axios":  "^1.12.2",
                          "cors":  "^2.8.5",
                          "firebase-admin":  "^12.6.0",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,23 +1,20 @@
 import {initializeApp} from "firebase-admin/app";
-// ZMĚNA: Odebrali jsme setGlobalOptions
 import {onCall, onRequest} from "firebase-functions/v2/https";
-import {VertexAI, HarmCategory, HarmBlockThreshold} from "@google-cloud/vertexai";
+import {GoogleGenAI, HarmCategory, HarmBlockThreshold} from "@google/genai";
 import {getStorage} from "firebase-admin/storage";
 import {Response} from "firebase-functions/v1";
 
 initializeApp();
 
+// Initialize the new SDK. It should automatically use the project's
+// default credentials and location when deployed on Cloud Functions.
+const genAI = new GoogleGenAI();
+
 // --- AI Funkce pro aplikaci ---
 
-// OPRAVA: Přidáváme .region("europe-west1") ke každé funkci
 export const generateText = onCall({region: "europe-west1"}, async (request) => {
-  const vertex_ai = new VertexAI({
-    project: "ai-sensei-czu-pilot",
-    location: "europe-west1",
-  });
-
   const model = "gemini-1.5-flash-001";
-  const generativeModel = vertex_ai.preview.getGenerativeModel({
+  const generativeModel = genAI.getGenerativeModel({
     model: model,
     generationConfig: {
       "maxOutputTokens": 8192,
@@ -59,15 +56,9 @@ export const generateText = onCall({region: "europe-west1"}, async (request) => 
   }
 });
 
-// OPRAVA: Přidáváme .region("europe-west1") ke každé funkci
 export const generateJson = onCall({region: "europe-west1"}, async (request) => {
-  const vertex_ai = new VertexAI({
-    project: "ai-sensei-czu-pilot",
-    location: "europe-west1",
-  });
-
   const model = "gemini-1.5-flash-001";
-  const generativeModel = vertex_ai.preview.getGenerativeModel({
+  const generativeModel = genAI.getGenerativeModel({
     model: model,
     generationConfig: {
       "responseMimeType": "application/json",
@@ -93,15 +84,9 @@ export const generateJson = onCall({region: "europe-west1"}, async (request) => 
   }
 });
 
-// OPRAVA: Přidáváme .region("europe-west1") ke každé funkci
 export const generateFromDocument = onCall({region: "europe-west1"}, async (request) => {
-  const vertex_ai = new VertexAI({
-    project: "ai-sensei-czu-pilot",
-    location: "europe-west1",
-  });
-
   const model = "gemini-1.5-flash-001";
-  const generativeModel = vertex_ai.preview.getGenerativeModel({
+  const generativeModel = genAI.getGenerativeModel({
     model: model,
   });
 
@@ -136,13 +121,11 @@ export const generateFromDocument = onCall({region: "europe-west1"}, async (requ
 
 // --- Placeholder funkce pro Telegram ---
 
-// OPRAVA: Přidáváme .region("europe-west1") ke každé funkci
 export const telegramWebhook = onRequest({region: "europe-west1"}, (req, res: Response) => {
   console.log("Telegram webhook called with:", req.body);
   res.status(200).send("Webhook received!");
 });
 
-// OPRAVA: Přidáváme .region("europe-west1") ke každé funkci
 export const sendMessageToStudent = onCall({region: "europe-west1"}, async (request) => {
   const studentId = request.data.studentId;
   const message = request.data.message;


### PR DESCRIPTION
This commit migrates the Cloud Functions from the deprecated `@google-cloud/vertexai` SDK to the new `@google/genai` SDK. This change addresses a regression where calls to the Gemini API were failing with `PERMISSION_DENIED` errors.

The `VertexAI` client has been replaced with the `GoogleGenAI` client, and the Cloud Functions have been refactored to use the new API. The `functions/package.json` file has been updated to reflect the new dependency.