### PR TITLE
fix(js): Export deleteDoc from firebase-init.js

### DIFF
--- a/public/js/firebase-init.js
+++ b/public/js/firebase-init.js
@@ -35,5 +35,5 @@ export const storage = getStorage(app);
 export const functions = getFunctions(app, 'europe-west1');
 // Export commonly used functions for convenience
 export { httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-functions.js";
-export { collection, getDocs, query, orderBy, doc, getDoc, setDoc, addDoc, serverTimestamp, updateDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+export { collection, getDocs, query, orderBy, doc, getDoc, setDoc, addDoc, serverTimestamp, updateDoc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 export { onAuthStateChanged, signOut, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";


### PR DESCRIPTION
This commit resolves a JavaScript module error that was preventing the application from loading. The error, `Uncaught SyntaxError: The requested module './firebase-init.js' does not provide an export named 'deleteDoc'`, occurred because `main.js` was attempting to import `deleteDoc` from `firebase-init.js`, but the function was not being re-exported.

This change adds `deleteDoc` to the list of functions re-exported from `firebase/firestore` in `public/js/firebase-init.js`. This resolves the import error and allows the application to load correctly.