### PR TITLE
fix(auth): Correct Firebase SDK module imports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="cs">
 <head>
     <meta charset="UTF-8">

--- a/public/js/firebase-init.js
+++ b/public/js/firebase-init.js
@@ -33,7 +33,3 @@ export const db = getFirestore(app);
 export const storage = getStorage(app);
 // Ensure the function is initialized with the correct region
 export const functions = getFunctions(app, 'europe-west1');
-// Export commonly used functions for convenience
-export { httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-functions.js";
-export { collection, getDocs, query, orderBy, doc, getDoc, setDoc, addDoc, serverTimestamp, updateDoc, deleteDoc } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
-export { onAuthStateChanged, signOut, signInAnonymously } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,10 +1,24 @@
 // --- HLAVNÍ SKRIPT APLIKACE ---
+import { auth, db, storage, functions } from './firebase-init.js';
+import { httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-functions.js";
 import {
-    auth, db, storage, functions, httpsCallable,
-    onAuthStateChanged, signOut, signInAnonymously,
-    createUserWithEmailAndPassword, signInWithEmailAndPassword,
-    collection, getDocs, doc, addDoc, updateDoc, deleteDoc, serverTimestamp, setDoc, writeBatch
-} from './firebase-init.js';
+    onAuthStateChanged,
+    signOut,
+    signInAnonymously,
+    createUserWithEmailAndPassword,
+    signInWithEmailAndPassword
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import {
+    collection,
+    getDocs,
+    doc,
+    addDoc,
+    updateDoc,
+    deleteDoc,
+    serverTimestamp,
+    setDoc,
+    writeBatch
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import { initializeUpload, initializeCourseMediaUpload } from './upload-handler.js';
 
     const generateTextFunction = httpsCallable(functions, 'generateText');


### PR DESCRIPTION
Resolves a critical JavaScript error (`Uncaught SyntaxError: The requested module './firebase-init.js' does not provide an export named '...'`) that caused a blank page on load.

The `firebase-init.js` module was incorrectly attempting to re-export functions from the Firebase SDK. This caused dependent modules like `main.js` to fail to load, preventing the application from rendering.

The fix refactors the module imports to follow the standard Firebase v9+ modular pattern:
- `firebase-init.js` is now only responsible for initializing and exporting the core service instances (auth, db, etc.).
- `main.js` now imports all necessary Firebase functions directly from the appropriate Firebase SDK modules.