### PR TITLE
Fix(functions): Correct TS2349 build error in `sendMessageToProfessor`

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -258,8 +258,8 @@ export const sendMessageToProfessor = onCall(
         const studentDoc = await db.collection('students').doc(studentId).get();
         const lessonDoc = await db.collection('lessons').doc(lessonId).get();
 
-        const studentEmail = studentDoc.exists() ? studentDoc.data()?.email : `Student ID: ${studentId}`;
-        const lessonTitle = lessonDoc.exists() ? lessonDoc.data()?.title : `Lekce ID: ${lessonId}`;
+        const studentEmail = studentDoc.exists ? studentDoc.data()?.email : `Student ID: ${studentId}`;
+        const lessonTitle = lessonDoc.exists ? lessonDoc.data()?.title : `Lekce ID: ${lessonId}`;
 
         const messageToProfessor = `
         📬 *Nová zpráva od studenta*


### PR DESCRIPTION
Resolved a critical TypeScript build error (`TS2349: This expression is not callable. Type 'Boolean' has no call signatures.`) in the `sendMessageToProfessor` cloud function.

The error was caused by incorrectly calling the `exists` property on a Firestore DocumentSnapshot as a function (`studentDoc.exists()`). The `exists` property is a boolean.

The fix replaces the incorrect function call `doc.exists()` with the correct property access `doc.exists`, allowing the TypeScript code to compile successfully.