### PR TITLE
Fix: Replace failing Firebase deployment action with official GCloud …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,17 +21,20 @@ jobs:
       - name: Install root dependencies
         run: npm install
 
-      - name: Install functions dependencies and build
+      - name: Install Functions dependencies and build
         run: |
           cd functions
           npm install
           npm run build
-          cd ..
+
+      - name: Authenticate to Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_AI_SENSEI_CZU_PILOT }}'
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
 
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@master
-        with:
-          args: deploy --only functions,hosting
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_AI_SENSEI_CZU_PILOT }}
-          PROJECT_ID: ai-sensei-czu-pilot
+        run: firebase deploy --only functions,hosting --project ai-sensei-czu-pilot --force


### PR DESCRIPTION
…auth

Replaces the deprecated and failing `w9jds/firebase-action@master` with the official `google-github-actions/auth@v2` for authenticating to Google Cloud.

This resolves the authentication error ('Invalid project selection') in the CI/CD pipeline and ensures a robust and correct deployment process for Firebase Hosting and Functions.