### PR TITLE
feat: Rename telegramWebhook to telegramBotWebhook

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -157,7 +157,7 @@ async function sendTelegramMessage(chatId: string | number, text: string) {
     }
 }
 
-export const telegramWebhook = onRequest(
+export const telegramBotWebhook = onRequest(
     { region: "europe-west1", cors: true },
     async (req, res) => {
         // Telegram sends a POST request


### PR DESCRIPTION
This commit renames the `telegramWebhook` Firebase Function to `telegramBotWebhook`.

This change is a workaround for a Firebase deployment issue that blocks the modification of a function's type. Renaming the function forces Firebase to treat it as a new function, bypassing the deployment block.