### PR TITLE
Updates the generative AI model from the deprecated `gemini-pro` to t…

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -42,7 +42,7 @@ export const generateText = onCall(
     { region: "europe-west1", cors: true, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.0-pro" });
 
         const prompt = request.data.prompt;
 
@@ -67,7 +67,7 @@ export const generateJson = onCall(
     { region: "europe-west1", cors: true, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.0-pro" });
 
         const prompt = request.data.prompt;
 
@@ -99,7 +99,7 @@ export const generateFromDocument = onCall(
     { region: "europe-west1", cors: true, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.0-pro" });
 
         const { filePath, prompt } = request.data;
         if (!filePath || !prompt) {
@@ -301,7 +301,7 @@ export const getLessonKeyTakeaways = onCall(
     { region: "europe-west1", cors: true, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.0-pro" });
 
         const { lessonText } = request.data;
         if (!lessonText) {
@@ -329,7 +329,7 @@ export const getAiAssistantResponse = onCall(
     { region: "europe-west1", cors: true, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.0-pro" });
 
         const { lessonText, userQuestion } = request.data;
         if (!lessonText || !userQuestion) {


### PR DESCRIPTION
…he current `gemini-1.0-pro`.

This change addresses a 500 Internal Server Error caused by a `404 Not Found` error when calling the Google Generative AI API. The `gemini-pro` model name is no longer valid for the API version being used by the SDK.

The model name has been updated in all five Cloud Functions that use the GoogleGenerativeAI client to ensure all AI-related features function correctly.