### PR TITLE
Fix: Correctly scope npm cache in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: functions/package-lock.json
 
       - name: Install root dependencies
         run: npm install


### PR DESCRIPTION
The previous workflow was caching npm dependencies based on the root package-lock.json file. This caused issues when the dependencies in the functions directory were updated, as the cache was not being correctly invalidated. This resulted in stale dependencies being used in the deployment, causing the application to use an old version of the @google/generative-ai SDK.

This change adds `cache-dependency-path: functions/package-lock.json` to the `setup-node` action. This ensures that the cache is correctly invalidated when the function's dependencies change, resolving the stale dependency issue.