### PR TITLE
chore: Disable dependency caching in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: functions/package-lock.json
 
       - name: Install root dependencies
         run: npm install


### PR DESCRIPTION
Temporarily disabled the npm dependency cache in the GitHub Actions deployment workflow. This is to force a clean installation of all dependencies during deployment to troubleshoot a production issue where outdated packages were being used.