### PR TITLE
fix(deploy): Point functions source to compiled `lib` directory

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -3,7 +3,7 @@
     "rules": "firestore.rules"
   },
   "functions": {
-    "source": "functions"
+    "source": "functions/lib"
   },
   "hosting": {
     "public": "public",


### PR DESCRIPTION
The `firebase.json` configuration was previously pointing the functions `source` to the `functions` directory. This created an ambiguity in the CI/CD pipeline, where the Firebase CLI would attempt to build the TypeScript source instead of using the pre-compiled JavaScript in the `lib` directory. This build would fail silently in the clean environment, causing a fallback to the last known-good deployment and resulting in a persistent production error.

By explicitly setting the `source` to `functions/lib`, we ensure that the deployment process uses the correct, compiled artifacts from the build step, resolving the deployment issue.