### PR TITLE
fix(deploy): Copy package.json to lib for runtime detection

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "scripts": {
     "lint": "eslint . --fix",
-    "build": "tsc",
+    "build": "tsc && cp package.json lib/",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",


### PR DESCRIPTION
The previous change to point `functions.source` to `functions/lib` in `firebase.json` was correct but incomplete. It caused a new deployment error because the compiled `lib` directory was missing the `package.json` file, which Firebase needs to determine the Node.js runtime and dependencies.

This commit updates the `build` script in `functions/package.json` to copy the `package.json` file into the `lib` directory after the TypeScript compilation (`tsc`) is finished. This ensures that the deployment artifact contains all the necessary metadata, resolving the `Could not detect runtime` error.