### PR TITLE
fix(functions): Switch to gemini-pro model to resolve API errors

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -46,7 +46,7 @@ export const generateText = onCall(
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
         // POUŽÍVÁME NOVĚJŠÍ MODEL
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
 
         const prompt = request.data.prompt;
 
@@ -71,7 +71,7 @@ export const generateJson = onCall(
     { region: "europe-west1", cors: allowedOrigins, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
 
         const prompt = request.data.prompt;
 
@@ -297,7 +297,7 @@ export const getLessonKeyTakeaways = onCall(
     { region: "europe-west1", cors: allowedOrigins, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
 
         const { lessonText } = request.data;
         if (!lessonText) {
@@ -325,7 +325,7 @@ export const getAiAssistantResponse = onCall(
     { region: "europe-west1", cors: allowedOrigins, secrets: ["GEMINI_API_KEY"] },
     async (request) => {
         const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-        const generativeModel = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+        const generativeModel = genAI.getGenerativeModel({ model: "gemini-pro" });
 
         const { lessonText, userQuestion } = request.data;
         if (!lessonText || !userQuestion) {


### PR DESCRIPTION
The `gemini-1.5-flash` model was causing 500 Internal Server Errors due to being unavailable with the `v1beta` API version in use.

This commit replaces `gemini-1.5-flash` with the stable `gemini-pro` model in the following Cloud Functions:
- generateText
- generateJson
- getLessonKeyTakeaways
- getAiAssistantResponse

This change ensures that the AI-powered features of the application can function correctly without being affected by model availability issues. The `gemini-pro-vision` model, used for document analysis, remains unchanged as it was not affected.