### PR TITLE
Update @google/generative-ai to v0.16.0

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "@google/generative-ai": "^0.15.0",
+        "@google/generative-ai": "^0.16.0",
         "@types/cors": "^2.8.19",
         "axios": "^1.12.2",
         "cors": "^2.8.5",
@@ -854,9 +854,9 @@
       }
     },
     "node_modules/@google/generative-ai": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.15.0.tgz",
-      "integrity": "sha512-zs37judcTYFJf1U7tnuqnh7gdzF6dcWj9pNRxjA5JTONRoiQ0htrRdbefRFiewOIfXwhun5t9hbd2ray7812eQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.16.1.tgz",
+      "integrity": "sha512-t4x4g0z/HT2BdBNfK2ua2xA/Az+SDFng4PxWjgiys/qxbh2YcrCI2rZg9/6eBkd4Iz41yjpCCDOWxsMryLJ7TA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -2782,9 +2782,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.11.tgz",
-      "integrity": "sha512-i+sRXGhz4+QW8aACZ3+r1GAKMt0wlFpeA8M5rOQd0HEYw9zhDrlx9Wc8uQ0IdXakjJRthzglEwfB/yqIjO6iDg==",
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
+      "integrity": "sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@google/generative-ai": "^0.15.0",
+    "@google/generative-ai": "^0.16.0",
     "@types/cors": "^2.8.19",
     "axios": "^1.12.2",
     "cors": "^2.8.5",


### PR DESCRIPTION
This change addresses a deployment failure caused by an outdated `@google/generative-ai` dependency specified in the `package-lock.json`.

The `package-lock.json` in the `functions` directory has been deleted and regenerated by running `npm install` after updating the `package.json` to ensure all dependencies are consistent and up-to-date.