### PR TITLE
Fix(deploy): Prevent stale dependencies in Firebase deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           cd functions
           npm ci
+          npm run lint
           npm run build
 
       - name: Authenticate to Google Cloud

--- a/firebase.json
+++ b/firebase.json
@@ -3,11 +3,7 @@
     "rules": "firestore.rules"
   },
   "functions": {
-    "source": "functions",
-    "predeploy": [
-      "npm --prefix \"$RESOURCE_DIR\" run lint",
-      "npm --prefix \"$RESOURCE_DIR\" run build"
-    ]
+    "source": "functions"
   },
   "hosting": {
     "public": "public",


### PR DESCRIPTION
The previous deployment process was suffering from a stale dependency issue where an old version of the `@google/generative-ai` library was being deployed, despite the `package-lock.json` being correct.

This was caused by a `predeploy` hook in `firebase.json` that triggered a redundant `npm run build` command on the Firebase server. This second build used a cached `node_modules` directory, overwriting the correctly built artifacts from the CI workflow.

This commit resolves the issue by:
1. Removing the `predeploy` hook from `firebase.json` to eliminate the redundant and problematic build step.
2. Moving the `npm run lint` command into the `.github/workflows/deploy.yml` file.

This ensures that the application is linted and built only once in a clean environment after `npm ci` is run, guaranteeing that the deployed code matches the committed code.