### PR TITLE
fix(functions): Remove node_modules from .gitignore

### DIFF
--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -6,5 +6,4 @@ lib/**/*.js.map
 typings/
 
 # Node.js dependency directory
-node_modules/
 *.local


### PR DESCRIPTION
Removes the `node_modules/` entry from the `functions/.gitignore` file.

This is a critical fix to resolve the deployment failure. The root cause was that the `.gitignore` file was causing the `node_modules` directory to be excluded from the deployment package. By removing this line, we ensure that the correctly installed dependencies from the CI/CD environment are packaged and deployed to Firebase, resolving the API errors caused by missing modules.