### PR TITLE
fix(functions): Remove node_modules from .gitignore

### DIFF
--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -2,5 +2,4 @@
 typings/
 
 # Node.js dependency directory
-node_modules/
 *.local


### PR DESCRIPTION
Removes `node_modules/` from the `functions/.gitignore` file.

This ensures that the installed dependencies from the CI workflow are included in the deployment package, fixing the deployment failure.