### PR TITLE
refactor(functions): Isolate Gemini API logic into a dedicated module

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "@google/generative-ai": "0.16.0",
+        "@google-cloud/vertexai": "^1.3.0",
         "@types/cors": "^2.8.19",
         "axios": "^1.12.2",
         "cors": "^2.8.5",
@@ -911,13 +911,69 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@google/generative-ai": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.16.0.tgz",
-      "integrity": "sha512-doB5ZNxS6m+jUZqaLCeYXfBZCdq6Ho0ibkq5/17xe1qAUZpCLWlvCDGtqFPqqO+yezNmvGatS0KhV22yiOT3DA==",
+    "node_modules/@google-cloud/vertexai": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.10.0.tgz",
+      "integrity": "sha512-HqYqoivNtkq59po8m7KI0n+lWKdz4kabENncYQXZCX/hBWJfXtKAfR/2nUQsP+TwSfHKoA7zDL2RrJYIv/j3VQ==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.1.0"
+      },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/vertexai/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -4809,7 +4865,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -4830,7 +4885,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5972,7 +6026,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7407,7 +7460,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9228,8 +9280,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
@@ -9905,8 +9956,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -9936,7 +9986,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "functions",
+  "type": "module",
   "scripts": {
     "lint": "eslint . --fix",
     "build": "tsc && cp package.json lib/",
@@ -15,7 +16,7 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "@google/generative-ai": "0.16.0",
+    "@google-cloud/vertexai": "^1.3.0",
     "@types/cors": "^2.8.19",
     "axios": "^1.12.2",
     "cors": "^2.8.5",

--- a/functions/src/gemini-api.ts
+++ b/functions/src/gemini-api.ts
@@ -1,0 +1,93 @@
+// functions/src/gemini-api.ts
+
+import {
+  VertexAI,
+  GenerativeModel,
+  GenerateContentRequest,
+} from "@google-cloud/vertexai";
+
+// 1. Centralized Initialization and Configuration
+const REGION = "europe-west1";
+const vertex_ai = new VertexAI({ project: process.env.GCLOUD_PROJECT, location: REGION });
+
+const MODELS = {
+  PRO: "gemini-1.5-pro-001",
+  VISION: "gemini-1.5-pro-vision-001"
+};
+
+const generativeModel = vertex_ai.getGenerativeModel({ model: MODELS.PRO });
+const generativeVisionModel = vertex_ai.getGenerativeModel({ model: MODELS.VISION });
+
+/**
+ * A reusable helper to stream responses from a Gemini model.
+ * @param model The Vertex AI model instance to use.
+ * @param requestBody The request payload for the model.
+ * @returns A promise that resolves to the aggregated text response.
+ */
+async function streamGeminiResponse(model: GenerativeModel, requestBody: GenerateContentRequest): Promise<string> {
+  // When running in the emulator, we can't make real API calls.
+  // Return a mock response to allow frontend testing.
+    if (process.env.FUNCTIONS_EMULATOR === "true") {
+        console.log("EMULATOR_MOCK: Bypassing real API call.");
+        // Return a mock JSON string for JSON requests, and plain text for others.
+        if (requestBody.generationConfig?.responseMimeType === "application/json") {
+            return JSON.stringify({ mock: "This is a mock JSON response from the emulator." });
+        }
+        return "This is a mock text response from the emulator because real API calls are not available locally.";
+    }
+  try {
+    const streamResult = await model.generateContentStream(requestBody);
+    let fullText = "";
+    for await (const item of streamResult.stream) {
+      if (item.candidates && item.candidates[0].content.parts[0].text) {
+        fullText += item.candidates[0].content.parts[0].text;
+      }
+    }
+    return fullText;
+  } catch (error) {
+    console.error("Error streaming Gemini response:", error);
+    throw new Error("Failed to get a valid response from the Gemini API.");
+  }
+}
+
+// 2. Export High-Level Functions for Your Application Logic
+export async function generateTextFromPrompt(prompt: string): Promise<string> {
+  const request: GenerateContentRequest = {
+    contents: [{ role: "user", parts: [{ text: prompt }] }],
+  };
+  return await streamGeminiResponse(generativeModel, request);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function generateJsonFromPrompt(prompt: string): Promise<any> {
+  const jsonPrompt = `${prompt}\n\nPlease provide the response in a valid JSON format.`;
+  const request: GenerateContentRequest = {
+    contents: [{ role: "user", parts: [{ text: jsonPrompt }] }],
+    generationConfig: {
+        responseMimeType: "application/json",
+    },
+  };
+  const rawJsonText = await streamGeminiResponse(generativeModel, request);
+  try {
+    return JSON.parse(rawJsonText);
+  } catch (_e) { // Changed 'e' to '_e' to satisfy the linter
+    console.error("Failed to parse JSON from Gemini:", rawJsonText);
+    throw new Error("Model returned invalid JSON.");
+  }
+}
+
+export async function generateTextFromDocument(filePath: string, prompt: string): Promise<string> {
+    const bucketName = "ai-sensei-czu-pilot.appspot.com";
+    const request: GenerateContentRequest = {
+        contents: [
+            {
+                role: "user",
+                parts: [
+                    { fileData: { mimeType: "application/pdf", fileUri: `gs://${bucketName}/${filePath}` } },
+                    { text: prompt },
+                ],
+            },
+        ],
+    };
+    return await streamGeminiResponse(generativeVisionModel, request);
+}


### PR DESCRIPTION
This change replaces the direct `axios` calls to the Vertex AI API with a dedicated client module that uses the `@google-cloud/vertexai` SDK. This resolves previous build and linting failures.

Key changes:
- Added the `@google-cloud/vertexai` dependency and `"type": "module"` to `package.json`.
- Created a new `functions/src/gemini-api.ts` module to centralize all API initialization, configuration, and request logic, including specific types and emulator support.
- Refactored the `generateText`, `generateJson`, `generateFromDocument`, `getLessonKeyTakeaways`, and `getAiAssistantResponse` Cloud Functions in `functions/src/index.ts` to use the new `GeminiAPI` module.
- Removed all old `axios`-based Gemini logic from `index.ts`.