### PR TITLE
Fix: Use available Gemini Flash model for europe-west1

### DIFF
--- a/functions/src/gemini-api.ts
+++ b/functions/src/gemini-api.ts
@@ -11,8 +11,8 @@ const REGION = "europe-west1";
 const vertex_ai = new VertexAI({ project: process.env.GCLOUD_PROJECT, location: REGION });
 
 const MODELS = {
-  PRO: "gemini-1.5-pro-001",
-  VISION: "gemini-1.5-pro-vision-001"
+  PRO: "gemini-1.5-flash-001",
+  VISION: "gemini-1.5-flash-001" // Note: 1.5 Flash is also multimodal
 };
 
 const generativeModel = vertex_ai.getGenerativeModel({ model: MODELS.PRO });


### PR DESCRIPTION
The `gemini-1.5-pro-001` model was not available in the `europe-west1` region, causing runtime errors in the deployed Cloud Functions.

This change switches to the `gemini-1.5-flash-001` model, which is confirmed to be available in the specified region. The VISION model is also updated to the flash version for consistency, as it is also multimodal.

This resolves the "Model not found" error while keeping the functions located in Europe for better performance for local users.