### PR TITLE
fix(functions): Use stable Gemini model identifiers

### DIFF
--- a/functions/src/gemini-api.ts
+++ b/functions/src/gemini-api.ts
@@ -11,8 +11,8 @@ const REGION = "europe-west1";
 const vertex_ai = new VertexAI({ project: process.env.GCLOUD_PROJECT, location: REGION });
 
 const MODELS = {
-  PRO: "gemini-1.5-flash-001",
-  VISION: "gemini-1.5-flash-001" // Note: 1.5 Flash is also multimodal
+  PRO: "gemini-pro",
+  VISION: "gemini-pro-vision"
 };
 
 const generativeModel = vertex_ai.getGenerativeModel({ model: MODELS.PRO });


### PR DESCRIPTION
Replaces version-specific model strings (e.g., "gemini-1.5-flash-001") with the stable, versionless identifiers ("gemini-pro" and "gemini-pro-vision") in the Vertex AI configuration.

This change resolves the "Model not found" runtime error that occurred because the specified model version was not available in the `europe-west1` region. Using the stable identifiers allows Google Cloud to automatically select the latest available stable version in the function's region, making the implementation more robust and less prone to regional availability issues.