### PR TITLE
Fix: Resolve CommonJS module conflict for local deployment

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,5 @@
 {
   "name": "functions",
-  "type": "module",
   "scripts": {
     "lint": "eslint . --fix",
     "build": "tsc",

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "outDir": "lib",


### PR DESCRIPTION
This commit addresses a build failure that occurred during local deployment (`firebase deploy --only functions`). The error `ReferenceError: exports is not defined in ES module scope` was caused by a module format mismatch.

The following changes have been made:
- `functions/package.json`: Removed `"type": "module"` to prevent Node.js from treating `.js` files as ES Modules by default.
- `functions/tsconfig.json`: Updated the TypeScript compiler options to explicitly output CommonJS modules, which is the format expected by the Firebase Functions runtime.
  - `module` changed from `NodeNext` to `CommonJS`.
  - `moduleResolution` changed from `NodeNext` to `Node`.

These changes align the project's module system with the Firebase runtime requirements, ensuring successful builds and deployments.