### PR TITLE
Fix: Update Firestore security rules to prevent 400 errors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,23 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
+
+    // Allow any authenticated user to read all lesson-related data.
+    // This is the primary fix for the 400 Bad Request on the /Listen channel.
+    // Write access is kept open for now to allow professors to manage content.
+    match /lessons/{lessonId}/{documents=**} {
       allow read, write: if request.auth != null;
+    }
+
+    // Secure student data: a user can only read/write their own documents.
+    match /students/{studentId}/{documents=**} {
+      allow read, write: if request.auth.uid == studentId;
+    }
+
+    // Allow any authenticated user to manage timeline events for now.
+    // This will be restricted to a professor role in the future.
+    match /timeline_events/{eventId} {
+       allow read, write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
Replaced the generic `allow read, write: if request.auth != null;` rule at the root with specific rules for each collection (`lessons`, `students`, `timeline_events`).

This change resolves a `400 Bad Request` error that occurred when the application attempted to fetch collections from Firestore. The previous generic rule was insufficient for Firestore's query engine, requiring explicit rules for each collection path.

The new rules maintain the existing logic of allowing authenticated users to read/write professor-managed collections while securing student data to be accessible only by the owning user.