### PR TITLE
feat: Clean build artifacts in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install root dependencies
         run: npm install
 
+      - name: Clean previous build artifacts
+        run: rm -rf functions/lib
+
       - name: Install Functions dependencies and build
         run: |
           cd functions


### PR DESCRIPTION
Adds a step to the GitHub Actions workflow to remove the `functions/lib` directory before installing dependencies and building the project.

This ensures that stale build artifacts are not deployed, which was the likely cause of a persistent "404 Not Found" error for the `generateFromDocument` Cloud Function.