### PR TITLE
feat: Implement professor-to-student Telegram messaging

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -9,9 +9,11 @@ service cloud.firestore {
       allow read, write: if request.auth != null;
     }
 
-    // Secure student data: a user can only read/write their own documents.
+    // Allow authenticated users (like professors) to read the list of students,
+    // but only allow a student to write to their own document.
     match /students/{studentId}/{documents=**} {
-      allow read, write: if request.auth.uid == studentId;
+      allow read: if request.auth != null;
+      allow write: if request.auth.uid == studentId;
     }
 
     // Allow any authenticated user to manage timeline events for now.


### PR DESCRIPTION
This commit introduces the functionality for professors to send messages to students via Telegram from the 'Student Interactions' dashboard.

A new `renderTelegramInteractionView` function has been added to `public/js/main.js`. This function fetches all students from Firestore, filters for those with a `telegramChatId`, and renders a UI card for each. Each card contains the student's email, a textarea for the message, and a 'Send' button.

The 'Send' button is now functional. It calls the `sendMessageToStudent` callable Cloud Function, passing the relevant `studentId` and message `text`. The UI provides feedback during this process by disabling the inputs and showing a loading indicator, followed by a success or error toast notification.

To enable this feature, the Firestore security rules have been updated. The rules for the `/students/{studentId}` path now allow any authenticated user to read the data, while write access remains restricted to the student themselves. This change is necessary for the professor's client to fetch the list of students to display.