### PR TITLE
refactor: Remove initial lesson data seeding

### DIFF
--- a/jules-scratch/verification/verify_no_seeding.py
+++ b/jules-scratch/verification/verify_no_seeding.py
@@ -1,0 +1,58 @@
+from playwright.sync_api import Page, expect
+import sys
+
+def test_no_data_seeding(page: Page):
+    """
+    This test verifies that the application no longer seeds the database
+    with initial lesson data if the 'lessons' collection is empty.
+    It now includes enhanced logging for debugging.
+    """
+
+    # Listen for all console events and print them to stdout
+    page.on("console", lambda msg: print(f"BROWSER CONSOLE: {msg.type}: {msg.text}"))
+    # Listen for page errors, which are critical
+    page.on("pageerror", lambda exc: print(f"PAGE ERROR: {exc}"))
+
+    try:
+        print("Navigating to http://127.0.0.1:5000...")
+        page.goto("http://127.0.0.1:5000", timeout=15000)
+        print("Navigation complete.")
+
+        print("Looking for professor login button...")
+        professor_login_button = page.get_by_role("button", name="Vstupte jako profesor")
+        expect(professor_login_button).to_be_visible(timeout=10000)
+        print("Professor login button found. Clicking...")
+        professor_login_button.click()
+
+        print("Waiting for professor dashboard to load...")
+        main_content_area = page.locator("#main-content-area")
+        expect(main_content_area).to_be_visible(timeout=15000)
+        print("Professor dashboard loaded.")
+
+        print("Checking for 'no lessons' message in all status columns...")
+        scheduled_lessons = page.locator("#lessons-scheduled")
+        active_lessons = page.locator("#lessons-active")
+        archived_lessons = page.locator("#lessons-archived")
+
+        expect(scheduled_lessons).to_contain_text("Žádné lekce v tomto stavu.", timeout=5000)
+        print("Checked 'scheduled' column.")
+        expect(active_lessons).to_contain_text("Žádné lekce v tomto stavu.", timeout=5000)
+        print("Checked 'active' column.")
+        expect(archived_lessons).to_contain_text("Žádné lekce v tomto stavu.", timeout=5000)
+        print("Checked 'archived' column.")
+
+        print("All assertions passed. Taking screenshot...")
+        screenshot_path = "jules-scratch/verification/verification.png"
+        page.screenshot(path=screenshot_path)
+        print(f"Screenshot saved to {screenshot_path}")
+
+    except Exception as e:
+        print(f"An error occurred during Playwright script execution: {e}", file=sys.stderr)
+        # Take a screenshot on failure to see the page state
+        page.screenshot(path="jules-scratch/verification/error.png")
+        print("Error screenshot saved to jules-scratch/verification/error.png", file=sys.stderr)
+        # Re-raise the exception to ensure the script exits with a non-zero code
+        raise
+
+    finally:
+        print("Verification script finished.")

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -182,21 +182,8 @@ import { initializeUpload, initializeCourseMediaUpload, renderMediaLibraryFiles 
         try {
             const querySnapshot = await getDocs(lessonsCollection);
             if (querySnapshot.empty) {
-                console.log("Databáze lekcí je prázdná, nahrávám počáteční data...");
-                const initialLessons = [
-                    { title: 'Úvod do Kvantové Fyziky', subtitle: 'Základní principy', number: '101', creationDate: '2025-09-20', status: 'Aktivní', icon: '⚛️', content: 'Vítejte ve fascinujícím světě kvantové mechaniky! Na rozdíl od klasické fyziky, která popisuje pohyb velkých objektů jako jsou planety nebo míče, kvantová mechanika se zabývá chováním hmoty a energie na atomární a subatomární úrovni. Jedním z klíčových a nejvíce matoucích principů je vlnově-korpuskulární dualismus, který říká, že částice jako elektrony se mohou chovat jednou jako částice a jindy jako vlny. Dalším stěžejním konceptem je princip superpozice. Představte si minci, která se točí ve vzduchu. Dokud nedopadne, není ani panna, ani orel - je v jakémsi stavu obou možností najednou. Podobně může být kvantová částice ve více stavech současně, dokud ji nezačneme měřit. Teprve měřením "donutíme" částici vybrat si jeden konkrétní stav.' },
-                    { title: 'Historie Starověkého Říma', subtitle: 'Od republiky k císařství', number: '203', creationDate: '2025-09-18', status: 'Aktivní', icon: '🏛️', content: 'Dějiny starověkého Říma jsou příběhem o vzestupu malé městské osady na Apeninském poloostrově v globální impérium. Počátky se datují do 8. století př. n. l. a končí pádem Západořímské říše v roce 476 n. l. Římská republika, založená kolem roku 509 př. n. l., byla charakteristická systémem volených magistrátů a silným senátem.' },
-                    { title: 'Základy botaniky', subtitle: 'Fotosyntéza a růst', number: 'B05', creationDate: '2025-09-15', status: 'Naplánováno', icon: '🌱', content: 'Botanika je věda o rostlinách. Klíčovým procesem pro život na Zemi je fotosyntéza, při které zelené rostliny využívají sluneční světlo, vodu a oxid uhličitý k výrobě glukózy (energie) a kyslíku. Tento proces probíhá v chloroplastech, které obsahují zelené barvivo chlorofyl.' },
-                    { title: 'Shakespearova dramata', subtitle: 'Tragédie a komedie', number: 'LIT3', creationDate: '2025-09-12', status: 'Archivováno', icon: '🎭', content: 'William Shakespeare je považován za jednoho z největších dramatiků všech dob. Jeho hry se dělí na tragédie (Hamlet, Romeo a Julie), komedie (Sen noci svatojánské) a historické hry. Jeho dílo je charakteristické komplexními postavami, poetickým jazykem a nadčasovými tématy lásky, zrady, moci a smrti.'},
-                    { title: 'Neuronové sítě', subtitle: 'Úvod do hlubokého učení', number: 'AI-5', creationDate: '2025-09-21', status: 'Naplánováno', icon: '🧠', content: 'Neuronové sítě jsou základním stavebním kamenem moderní umělé inteligence a hlubokého učení. Jsou inspirovány strukturou lidského mozku a skládají se z propojených uzlů neboli "neuronů", které zpracovávají a přenášejí informace. Učí se na základě velkých objemů dat tím, že upravují váhy spojení mezi neurony.' },
-                ];
-                for (const lesson of initialLessons) {
-                    await addDoc(lessonsCollection, { ...lesson, createdAt: serverTimestamp() });
-                }
-                // After seeding, fetch the data again to get the generated IDs
-                const newQuerySnapshot = await getDocs(lessonsCollection);
-                lessonsData = newQuerySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-
+                console.log("Database is empty, no lessons to display.");
+                lessonsData = [];
             } else {
                  lessonsData = querySnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
             }


### PR DESCRIPTION
The application no longer requires the initial sample lessons to be automatically added to an empty Firestore database.

This change modifies the `fetchLessons` async function in `public/js/main.js`. The `if (querySnapshot.empty)` block has been updated to log a console message and ensure the `lessonsData` array remains empty, instead of populating the database with mock data.