### PR TITLE
Standardize external dependencies and resolve CDN crashes

### DIFF
--- a/public/js/views/professor/professor-analytics-view.js
+++ b/public/js/views/professor/professor-analytics-view.js
@@ -5,7 +5,7 @@ import { httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.2/fireba
 import { collection, query, where, getDocs, doc, onSnapshot } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import { functions, db, auth } from '../../firebase-init.js';
 import { showToast, getCollectionPath } from '../../utils/utils.js';
-import Chart from 'https://esm.sh/chart.js/auto';
+import Chart from 'https://cdn.jsdelivr.net/npm/chart.js/auto/+esm';
 
 export class ProfessorAnalyticsView extends Localized(LitElement) {
     static properties = {

--- a/public/js/views/student/chat-panel.js
+++ b/public/js/views/student/chat-panel.js
@@ -1,6 +1,6 @@
 // Súbor: public/js/student/chat-panel.js
 
-import { LitElement, html } from 'https://cdn.skypack.dev/lit';
+import { LitElement, html } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 import { collection, query, where, orderBy, onSnapshot, addDoc, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import { httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-functions.js";
 import { showToast } from '../../utils/utils.js';

--- a/public/js/views/student/mission-comms.js
+++ b/public/js/views/student/mission-comms.js
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'https://cdn.skypack.dev/lit';
+import { LitElement, html } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 import { collection, query, where, orderBy, onSnapshot, addDoc, serverTimestamp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import { httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-functions.js";
 import { showToast } from '../../utils/utils.js';

--- a/public/js/views/student/student-class-detail.js
+++ b/public/js/views/student/student-class-detail.js
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing } from 'https://cdn.skypack.dev/lit';
+import { LitElement, html, nothing } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 import { doc, getDoc, updateDoc, arrayRemove, collection, query, where, orderBy, onSnapshot } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import * as firebaseInit from '../../firebase-init.js';
 import { translationService } from '../../utils/translation-service.js';

--- a/public/js/views/student/student-classes-view.js
+++ b/public/js/views/student/student-classes-view.js
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing } from 'https://cdn.skypack.dev/lit';
+import { LitElement, html, nothing } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 import { doc, onSnapshot, collection, query, where, getDocs } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 import * as firebaseInit from '../../firebase-init.js';
 import { translationService } from '../../utils/translation-service.js';

--- a/public/js/views/student/test-component.js
+++ b/public/js/views/student/test-component.js
@@ -1,6 +1,6 @@
 // Súbor: public/js/student/test-component.js
 
-import { LitElement, html } from 'https://cdn.skypack.dev/lit';
+import { LitElement, html } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 import { showToast } from '../../utils/utils.js';
 import * as firebaseInit from '../../firebase-init.js';
 import { httpsCallable } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-functions.js";


### PR DESCRIPTION
Standardized external dependencies to resolve critical frontend crashes.
- Replaced all occurrences of `https://cdn.skypack.dev/lit` with `https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js` in `chat-panel.js`, `test-component.js`, `student-classes-view.js`, `mission-comms.js`, and `student-class-detail.js`.
- Replaced `https://esm.sh/chart.js/auto` with `https://cdn.jsdelivr.net/npm/chart.js/auto/+esm` in `professor-analytics-view.js`.
- Verified changes by confirming the application loads without Lit/Skypack related errors using Playwright.

---
*PR created automatically by Jules for task [7284318741435858334](https://jules.google.com/task/7284318741435858334) started by @Kamibony*